### PR TITLE
ProductFragment and ProductListFragment layout inflation

### DIFF
--- a/BasicSample/app/src/main/java/com/example/android/persistence/ProductFragment.java
+++ b/BasicSample/app/src/main/java/com/example/android/persistence/ProductFragment.java
@@ -19,7 +19,6 @@ package com.example.android.persistence;
 import android.arch.lifecycle.LifecycleFragment;
 import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProviders;
-import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
@@ -47,13 +46,18 @@ public class ProductFragment extends LifecycleFragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
-            @Nullable Bundle savedInstanceState) {
-        // Inflate this data binding layout
-        mBinding = DataBindingUtil.inflate(inflater, R.layout.product_fragment, container, false);
+                             @Nullable Bundle savedInstanceState) {
+        if (mBinding == null) {
+            View rootView = inflater.inflate(R.layout.product_fragment, container, false);
 
-        // Create and set the adapter for the RecyclerView.
-        mCommentAdapter = new CommentAdapter(mCommentClickCallback);
-        mBinding.commentList.setAdapter(mCommentAdapter);
+            //attach inflated view to binding layout
+            mBinding = ProductFragmentBinding.bind(rootView);
+
+            // Create and set the adapter for the RecyclerView.
+            mCommentAdapter = new CommentAdapter(mCommentClickCallback);
+            mBinding.commentList.setAdapter(mCommentAdapter);
+        }
+
         return mBinding.getRoot();
     }
 
@@ -103,7 +107,9 @@ public class ProductFragment extends LifecycleFragment {
         });
     }
 
-    /** Creates product fragment for specific product ID */
+    /**
+     * Creates product fragment for specific product ID
+     */
     public static ProductFragment forProduct(int productId) {
         ProductFragment fragment = new ProductFragment();
         Bundle args = new Bundle();

--- a/BasicSample/app/src/main/java/com/example/android/persistence/ProductListFragment.java
+++ b/BasicSample/app/src/main/java/com/example/android/persistence/ProductListFragment.java
@@ -20,7 +20,6 @@ import android.arch.lifecycle.Lifecycle;
 import android.arch.lifecycle.LifecycleFragment;
 import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProviders;
-import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
@@ -47,11 +46,17 @@ public class ProductListFragment extends LifecycleFragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
-            @Nullable Bundle savedInstanceState) {
-        mBinding = DataBindingUtil.inflate(inflater, R.layout.list_fragment, container, false);
+                             @Nullable Bundle savedInstanceState) {
+        if (mBinding == null) {
+            View rootView = inflater.inflate(R.layout.list_fragment, container, false);
 
-        mProductAdapter = new ProductAdapter(mProductClickCallback);
-        mBinding.productsList.setAdapter(mProductAdapter);
+            //attach inflated view to binding layout
+            mBinding = ListFragmentBinding.bind(rootView);
+
+            // Create and set the adapter for the RecyclerView
+            mProductAdapter = new ProductAdapter(mProductClickCallback);
+            mBinding.productsList.setAdapter(mProductAdapter);
+        }
 
         return mBinding.getRoot();
     }


### PR DESCRIPTION
ProductFragment and ProductListFragment databinding creation method changed due to it may cause memory. To prevent mentioned issue first checked binding created before. With new implementation it prevent re inflation for example if user press back button when user at product, current code re inflate product list but it redundant because we can access view via mBinding object.