### PR TITLE
Reformat BasicRxJavaSample

### DIFF
--- a/BasicRxJavaSample/app/src/androidTest/java/com/example/android/observability/persistence/LocalUserDataSourceTest.java
+++ b/BasicRxJavaSample/app/src/androidTest/java/com/example/android/observability/persistence/LocalUserDataSourceTest.java
@@ -16,9 +16,12 @@
 
 package com.example.android.observability.persistence;
 
+import android.content.Context;
+
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.room.Room;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -29,11 +32,9 @@ import org.junit.Test;
  */
 public class LocalUserDataSourceTest {
 
+    private static final User USER = new User("id", "username");
     @Rule
     public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
-
-    private static final User USER = new User("id", "username");
-
     private UsersDatabase mDatabase;
     private LocalUserDataSource mDataSource;
 
@@ -41,8 +42,8 @@ public class LocalUserDataSourceTest {
     public void initDb() {
         // using an in-memory database because the information stored here disappears when the
         // process is killed
-        mDatabase = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(),
-                UsersDatabase.class)
+        Context context = ApplicationProvider.getApplicationContext();
+        mDatabase = Room.inMemoryDatabaseBuilder(context, UsersDatabase.class)
                 // allowing main thread queries, just for testing
                 .allowMainThreadQueries()
                 .build();
@@ -63,11 +64,7 @@ public class LocalUserDataSourceTest {
         mDataSource.getUser()
                 .test()
                 // assertValue asserts that there was only one emission of the user
-                .assertValue(user -> {
-                    // The emitted user is the expected one
-                    return user != null && user.getId().equals(USER.getId()) &&
-                            user.getUserName().equals(USER.getUserName());
-                });
+                .assertValue(USER);
     }
 
     @Test

--- a/BasicRxJavaSample/app/src/androidTest/java/com/example/android/observability/persistence/UserDaoTest.java
+++ b/BasicRxJavaSample/app/src/androidTest/java/com/example/android/observability/persistence/UserDaoTest.java
@@ -16,10 +16,13 @@
 
 package com.example.android.observability.persistence;
 
+import android.content.Context;
+
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.room.Room;
-import androidx.test.InstrumentationRegistry;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -29,25 +32,25 @@ import org.junit.runner.RunWith;
 /**
  * Test the implementation of {@link UserDao}
  */
-@RunWith(AndroidJUnit4.class)
+@RunWith(AndroidJUnit4ClassRunner.class)
 public class UserDaoTest {
 
+    private static final User USER = new User("id", "username");
     @Rule
     public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
-
-    private static final User USER = new User("id", "username");
-
     private UsersDatabase mDatabase;
+    private UserDao dao;
 
     @Before
     public void initDb() {
         // using an in-memory database because the information stored here disappears when the
         // process is killed
-        mDatabase = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(),
-                UsersDatabase.class)
+        Context context = ApplicationProvider.getApplicationContext();
+        mDatabase = Room.inMemoryDatabaseBuilder(context, UsersDatabase.class)
                 // allowing main thread queries, just for testing
                 .allowMainThreadQueries()
                 .build();
+        dao = mDatabase.userDao();
     }
 
     @After
@@ -57,7 +60,7 @@ public class UserDaoTest {
 
     @Test
     public void getUsersWhenNoUserInserted() {
-        mDatabase.userDao().getUser()
+        dao.getUser()
                 .test()
                 .assertNoValues();
     }
@@ -65,30 +68,26 @@ public class UserDaoTest {
     @Test
     public void insertAndGetUser() {
         // When inserting a new user in the data source
-        mDatabase.userDao().insertUser(USER).blockingAwait();
+        dao.insertUser(USER).blockingAwait();
 
         // When subscribing to the emissions of the user
-        mDatabase.userDao().getUser()
+        dao.getUser()
                 .test()
                 // assertValue asserts that there was only one emission of the user
-                .assertValue(user -> {
-                    // The emitted user is the expected one
-                    return user != null && user.getId().equals(USER.getId()) &&
-                            user.getUserName().equals(USER.getUserName());
-                });
+                .assertValue(USER);
     }
 
     @Test
     public void updateAndGetUser() {
         // Given that we have a user in the data source
-        mDatabase.userDao().insertUser(USER).blockingAwait();
+        dao.insertUser(USER).blockingAwait();
 
         // When we are updating the name of the user
         User updatedUser = new User(USER.getId(), "new username");
-        mDatabase.userDao().insertUser(updatedUser).blockingAwait();
+        dao.insertUser(updatedUser).blockingAwait();
 
         // When subscribing to the emissions of the user
-        mDatabase.userDao().getUser()
+        dao.getUser()
                 .test()
                 // assertValue asserts that there was only one emission of the user
                 .assertValue(user -> {
@@ -101,12 +100,12 @@ public class UserDaoTest {
     @Test
     public void deleteAndGetUser() {
         // Given that we have a user in the data source
-        mDatabase.userDao().insertUser(USER).blockingAwait();
+        dao.insertUser(USER).blockingAwait();
 
         //When we are deleting all users
-        mDatabase.userDao().deleteAllUsers();
+        dao.deleteAllUsers();
         // When subscribing to the emissions of the user
-        mDatabase.userDao().getUser()
+        dao.getUser()
                 .test()
                 // check that there's no user emitted
                 .assertNoValues();

--- a/BasicRxJavaSample/app/src/main/java/com/example/android/observability/Injection.java
+++ b/BasicRxJavaSample/app/src/main/java/com/example/android/observability/Injection.java
@@ -17,6 +17,9 @@
 package com.example.android.observability;
 
 import android.content.Context;
+
+import androidx.annotation.NonNull;
+
 import com.example.android.observability.persistence.LocalUserDataSource;
 import com.example.android.observability.persistence.UsersDatabase;
 import com.example.android.observability.ui.ViewModelFactory;
@@ -26,12 +29,14 @@ import com.example.android.observability.ui.ViewModelFactory;
  */
 public class Injection {
 
-    public static UserDataSource provideUserDataSource(Context context) {
+    @NonNull
+    private static UserDataSource provideUserDataSource(@NonNull Context context) {
         UsersDatabase database = UsersDatabase.getInstance(context);
         return new LocalUserDataSource(database.userDao());
     }
 
-    public static ViewModelFactory provideViewModelFactory(Context context) {
+    @NonNull
+    public static ViewModelFactory provideViewModelFactory(@NonNull Context context) {
         UserDataSource dataSource = provideUserDataSource(context);
         return new ViewModelFactory(dataSource);
     }

--- a/BasicRxJavaSample/app/src/main/java/com/example/android/observability/UserDataSource.java
+++ b/BasicRxJavaSample/app/src/main/java/com/example/android/observability/UserDataSource.java
@@ -16,6 +16,8 @@
 
 package com.example.android.observability;
 
+import androidx.annotation.NonNull;
+
 import com.example.android.observability.persistence.User;
 
 import io.reactivex.Completable;
@@ -31,6 +33,7 @@ public interface UserDataSource {
      *
      * @return the user from the data source.
      */
+    @NonNull
     Flowable<User> getUser();
 
     /**
@@ -38,6 +41,7 @@ public interface UserDataSource {
      *
      * @param user the user to be inserted or updated.
      */
+    @NonNull
     Completable insertOrUpdateUser(User user);
 
     /**

--- a/BasicRxJavaSample/app/src/main/java/com/example/android/observability/persistence/LocalUserDataSource.java
+++ b/BasicRxJavaSample/app/src/main/java/com/example/android/observability/persistence/LocalUserDataSource.java
@@ -16,6 +16,8 @@
 
 package com.example.android.observability.persistence;
 
+import androidx.annotation.NonNull;
+
 import com.example.android.observability.UserDataSource;
 
 import io.reactivex.Completable;
@@ -26,20 +28,23 @@ import io.reactivex.Flowable;
  */
 public class LocalUserDataSource implements UserDataSource {
 
+    @NonNull
     private final UserDao mUserDao;
 
-    public LocalUserDataSource(UserDao userDao) {
+    public LocalUserDataSource(@NonNull UserDao userDao) {
         mUserDao = userDao;
     }
 
+    @NonNull
     @Override
     public Flowable<User> getUser() {
         return mUserDao.getUser();
     }
 
+    @NonNull
     @Override
     public Completable insertOrUpdateUser(User user) {
-       return mUserDao.insertUser(user);
+        return mUserDao.insertUser(user);
     }
 
     @Override

--- a/BasicRxJavaSample/app/src/main/java/com/example/android/observability/persistence/User.java
+++ b/BasicRxJavaSample/app/src/main/java/com/example/android/observability/persistence/User.java
@@ -16,11 +16,12 @@
 
 package com.example.android.observability.persistence;
 
+import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.Ignore;
 import androidx.room.PrimaryKey;
-import androidx.annotation.NonNull;
+
 import java.util.UUID;
 
 /**
@@ -32,27 +33,48 @@ public class User {
     @NonNull
     @PrimaryKey
     @ColumnInfo(name = "userid")
-    private String mId;
+    private final String mId;
 
+    @NonNull
     @ColumnInfo(name = "username")
-    private String mUserName;
+    private final String mUserName;
 
-    @Ignore
-    public User(String userName) {
+    @Ignore// forbid room from using this constructor
+    public User(@NonNull String userName) {
         mId = UUID.randomUUID().toString();
         mUserName = userName;
     }
 
-    public User(String id, String userName) {
+    public User(@NonNull String id, @NonNull String userName) {
         this.mId = id;
         this.mUserName = userName;
     }
 
+    @NonNull
     public String getId() {
         return mId;
     }
 
+    @NonNull
     public String getUserName() {
         return mUserName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        User user = (User) o;
+
+        if (!mId.equals(user.mId)) return false;
+        return mUserName.equals(user.mUserName);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mId.hashCode();
+        result = 31 * result + mUserName.hashCode();
+        return result;
     }
 }

--- a/BasicRxJavaSample/app/src/main/java/com/example/android/observability/persistence/UsersDatabase.java
+++ b/BasicRxJavaSample/app/src/main/java/com/example/android/observability/persistence/UsersDatabase.java
@@ -16,10 +16,12 @@
 
 package com.example.android.observability.persistence;
 
+import android.content.Context;
+
+import androidx.annotation.NonNull;
 import androidx.room.Database;
 import androidx.room.Room;
 import androidx.room.RoomDatabase;
-import android.content.Context;
 
 /**
  * The Room database that contains the Users table
@@ -29,9 +31,7 @@ public abstract class UsersDatabase extends RoomDatabase {
 
     private static volatile UsersDatabase INSTANCE;
 
-    public abstract UserDao userDao();
-
-    public static UsersDatabase getInstance(Context context) {
+    public static UsersDatabase getInstance(@NonNull Context context) {
         if (INSTANCE == null) {
             synchronized (UsersDatabase.class) {
                 if (INSTANCE == null) {
@@ -43,5 +43,7 @@ public abstract class UsersDatabase extends RoomDatabase {
         }
         return INSTANCE;
     }
+
+    public abstract UserDao userDao();
 
 }

--- a/BasicRxJavaSample/app/src/main/java/com/example/android/observability/ui/UserViewModel.java
+++ b/BasicRxJavaSample/app/src/main/java/com/example/android/observability/ui/UserViewModel.java
@@ -16,10 +16,13 @@
 
 package com.example.android.observability.ui;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.ViewModel;
+
 import com.example.android.observability.UserDataSource;
 import com.example.android.observability.persistence.User;
 
-import androidx.lifecycle.ViewModel;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 
@@ -28,11 +31,13 @@ import io.reactivex.Flowable;
  */
 public class UserViewModel extends ViewModel {
 
+    @NonNull
     private final UserDataSource mDataSource;
 
+    @Nullable
     private User mUser;
 
-    public UserViewModel(UserDataSource dataSource) {
+    public UserViewModel(@NonNull UserDataSource dataSource) {
         mDataSource = dataSource;
     }
 
@@ -41,6 +46,7 @@ public class UserViewModel extends ViewModel {
      *
      * @return a {@link Flowable} that will emit every time the user name has been updated.
      */
+    @NonNull
     public Flowable<String> getUserName() {
         return mDataSource.getUser()
                 // for every emission of the user, get the user name
@@ -57,7 +63,8 @@ public class UserViewModel extends ViewModel {
      * @param userName the new user name
      * @return a {@link Completable} that completes when the user name is updated
      */
-    public Completable updateUserName(final String userName) {
+    @NonNull
+    public Completable updateUserName(@NonNull final String userName) {
         // if there's no user, create a new user.
         // if we already have a user, then, since the user object is immutable,
         // create a new user, with the id of the previous user and the updated user name.

--- a/BasicRxJavaSample/app/src/main/java/com/example/android/observability/ui/ViewModelFactory.java
+++ b/BasicRxJavaSample/app/src/main/java/com/example/android/observability/ui/ViewModelFactory.java
@@ -16,8 +16,10 @@
 
 package com.example.android.observability.ui;
 
+import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
+
 import com.example.android.observability.UserDataSource;
 
 /**
@@ -31,9 +33,11 @@ public class ViewModelFactory implements ViewModelProvider.Factory {
         mDataSource = dataSource;
     }
 
+    @NonNull
     @Override
-    public <T extends ViewModel> T create(Class<T> modelClass) {
+    public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
         if (modelClass.isAssignableFrom(UserViewModel.class)) {
+            //noinspection unchecked
             return (T) new UserViewModel(mDataSource);
         }
         throw new IllegalArgumentException("Unknown ViewModel class");

--- a/BasicRxJavaSample/app/src/test/java/com/example/android/observability/UserViewModelTest.java
+++ b/BasicRxJavaSample/app/src/test/java/com/example/android/observability/UserViewModelTest.java
@@ -16,13 +16,11 @@
 
 package com.example.android.observability;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+
 import com.example.android.observability.persistence.User;
 import com.example.android.observability.ui.UserViewModel;
+
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -34,6 +32,11 @@ import org.mockito.MockitoAnnotations;
 
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit test for {@link UserViewModel}
@@ -61,7 +64,7 @@ public class UserViewModelTest {
     @Test
     public void getUserName_whenNoUserSaved() {
         // Given that the UserDataSource returns an empty list of users
-        when(mDataSource.getUser()).thenReturn(Flowable.<User>empty());
+        when(mDataSource.getUser()).thenReturn(Flowable.empty());
 
         //When getting the user name
         mViewModel.getUserName()


### PR DESCRIPTION
+ Override `equals()` and `hashCode()` to User
+ Migrate from deprecated classes and methods, eg: `InstrumentationRegistry.getContext()` -> `ApplicationProvider.getApplicationContext()`
+ Add `@NotNull` and `@Nullable` annotations
+ Reformat and rearrange.