### PR TITLE
Remove useless submitList

### DIFF
--- a/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/RedditActivity.kt
+++ b/PagingWithNetworkSample/app/src/main/java/com/android/example/paging/pagingwithnetwork/reddit/ui/RedditActivity.kt
@@ -130,7 +130,6 @@ class RedditActivity : AppCompatActivity() {
             if (it.isNotEmpty()) {
                 if (model.showSubreddit(it)) {
                     list.scrollToPosition(0)
-                    (list.adapter as? PostsAdapter)?.submitList(null)
                 }
             }
         }


### PR DESCRIPTION
I removed that line because in certain situation it causes the adapter to show empty items when it has to show searched posts.
It works as it is intended to without calling submitList(null).

It happens when the response from the api is faster than submitList(null). Because submitList() checks diff on the background thread, it can return empty list after the api response, resulting the adapter to show empty list.

