### PR TITLE
Prevent memory leaks in AutoClearedValue

### DIFF
--- a/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/AutoClearedValueTest.kt
+++ b/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/AutoClearedValueTest.kt
@@ -15,6 +15,10 @@
  */
 package com.android.example.github.util
 
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.test.platform.app.InstrumentationRegistry
@@ -78,5 +82,13 @@ class AutoClearedValueTest {
 
     class TestFragment : Fragment() {
         var testValue by autoCleared<String>()
+
+        override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+        ): View? {
+            return View(context)
+        }
     }
 }

--- a/GithubBrowserSample/app/src/main/java/com/android/example/github/util/AutoClearedValue.kt
+++ b/GithubBrowserSample/app/src/main/java/com/android/example/github/util/AutoClearedValue.kt
@@ -32,10 +32,22 @@ class AutoClearedValue<T : Any>(val fragment: Fragment) : ReadWriteProperty<Frag
     private var _value: T? = null
 
     init {
-        fragment.lifecycle.addObserver(object : LifecycleObserver {
+        var observerRegistered = false
+        val viewObserver = object : LifecycleObserver {
             @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-            fun onDestroy() {
+            fun onDestroyView() {
+                observerRegistered = false
                 _value = null
+            }
+        }
+
+        fragment.lifecycle.addObserver(object : LifecycleObserver {
+            @OnLifecycleEvent(Lifecycle.Event.ON_START)
+            fun onStart() {
+                if (!observerRegistered) {
+                    fragment.viewLifecycleOwner.lifecycle.addObserver(viewObserver)
+                    observerRegistered = true
+                }
             }
         })
     }


### PR DESCRIPTION
When using AutoClearedValue we expect it to clear the value as soon
as the fragment view is destroyed. But in fact, the value is cleared
only when the fragment itself is destroyed, which makes AutoClearedValue
useless as the destroyed fragment is already available to be garbage
collected.

In order to solve the problem we should instead use viewLifecycleOwner.
But it's not available right away, so we wait till fragment lifecycle
ON_START event.