### PR TITLE
Enable new benchmark reporting for non-canary users

### DIFF
--- a/GithubBrowserSample/gradle.properties
+++ b/GithubBrowserSample/gradle.properties
@@ -34,3 +34,4 @@ org.gradle.jvmargs=-Xmx4536m
 android.databinding.enableV2=true
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableAdditionalTestOutput=true

--- a/PagingWithNetworkSample/gradle.properties
+++ b/PagingWithNetworkSample/gradle.properties
@@ -33,3 +33,4 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableAdditionalTestOutput=true


### PR DESCRIPTION
This should make it easier to run the sample out of the box for users on 29+ devices, but haven't yet upgraded to a version of studio that enables test output via AGP by default