### PR TITLE
Avoid references to the Fragment's Views after onDestroyView()

### DIFF
--- a/BasicSample/app/src/main/java/com/example/android/persistence/ui/ProductFragment.java
+++ b/BasicSample/app/src/main/java/com/example/android/persistence/ui/ProductFragment.java
@@ -87,6 +87,13 @@ public class ProductFragment extends Fragment {
         });
     }
 
+    @Override
+    public void onDestroyView() {
+        mBinding = null;
+        mCommentAdapter = null;
+        super.onDestroyView();
+    }
+
     /** Creates product fragment for specific product ID */
     public static ProductFragment forProduct(int productId) {
         ProductFragment fragment = new ProductFragment();

--- a/BasicSample/app/src/main/java/com/example/android/persistence/ui/ProductListFragment.java
+++ b/BasicSample/app/src/main/java/com/example/android/persistence/ui/ProductListFragment.java
@@ -90,6 +90,13 @@ public class ProductListFragment extends Fragment {
         });
     }
 
+    @Override
+    public void onDestroyView() {
+        mBinding = null;
+        mProductAdapter = null;
+        super.onDestroyView();
+    }
+
     private final ProductClickCallback mProductClickCallback = product -> {
         if (getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.STARTED)) {
             ((MainActivity) requireActivity()).show(product);

--- a/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/AutoClearedValueTest.kt
+++ b/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/AutoClearedValueTest.kt
@@ -15,6 +15,10 @@
  */
 package com.android.example.github.util
 
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.test.platform.app.InstrumentationRegistry
@@ -47,7 +51,6 @@ class AutoClearedValueTest {
 
     @Test
     fun clearOnReplace() {
-        testFragment.testValue = "foo"
         activityRule.activity.replaceFragment(TestFragment())
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         try {
@@ -58,8 +61,21 @@ class AutoClearedValueTest {
     }
 
     @Test
+    fun clearOnReplaceBackStack() {
+        activityRule.activity.replaceFragment(TestFragment(), true)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        try {
+            testFragment.testValue
+            Assert.fail("should throw if accessed when not set")
+        } catch (ex: IllegalStateException) {
+        }
+        activityRule.activity.supportFragmentManager.popBackStack()
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        assertThat(testFragment.testValue, `is`("foo"))
+    }
+
+    @Test
     fun dontClearForChildFragment() {
-        testFragment.testValue = "foo"
         testFragment.childFragmentManager.beginTransaction()
             .add(Fragment(), "foo").commit()
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
@@ -68,9 +84,8 @@ class AutoClearedValueTest {
 
     @Test
     fun dontClearForDialog() {
-        testFragment.testValue = "foo"
         val dialogFragment = DialogFragment()
-        dialogFragment.show(testFragment.fragmentManager!!, "dialog")
+        dialogFragment.show(testFragment.parentFragmentManager, "dialog")
         dialogFragment.dismiss()
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         assertThat(testFragment.testValue, `is`("foo"))
@@ -78,5 +93,11 @@ class AutoClearedValueTest {
 
     class TestFragment : Fragment() {
         var testValue by autoCleared<String>()
+
+        override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                savedInstanceState: Bundle?): View? {
+            testValue = "foo"
+            return View(context)
+        }
     }
 }

--- a/GithubBrowserSample/app/src/debug/java/com/android/example/github/testing/SingleFragmentActivity.kt
+++ b/GithubBrowserSample/app/src/debug/java/com/android/example/github/testing/SingleFragmentActivity.kt
@@ -46,9 +46,14 @@ class SingleFragmentActivity : AppCompatActivity() {
             .commit()
     }
 
-    fun replaceFragment(fragment: Fragment) {
+    fun replaceFragment(fragment: Fragment, addToBackStack: Boolean = false) {
         supportFragmentManager.beginTransaction()
             .replace(R.id.container, fragment)
+            .apply {
+                if (addToBackStack) {
+                    addToBackStack(null)
+                }
+            }
             .commit()
     }
 }

--- a/NavigationAdvancedSample/app/src/main/java/com/example/android/navigationadvancedsample/listscreen/Leaderboard.kt
+++ b/NavigationAdvancedSample/app/src/main/java/com/example/android/navigationadvancedsample/listscreen/Leaderboard.kt
@@ -33,17 +33,14 @@ import com.example.android.navigationadvancedsample.R
  */
 class Leaderboard : Fragment() {
 
-    private lateinit var recyclerView: RecyclerView
-    private lateinit var viewAdapter: RecyclerView.Adapter<*>
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment
         val view = inflater.inflate(R.layout.fragment_leaderboard, container, false)
 
-        viewAdapter = MyAdapter(Array(10) { "Person ${it + 1}" })
+        val viewAdapter = MyAdapter(Array(10) { "Person ${it + 1}" })
 
-        recyclerView = view.findViewById<RecyclerView>(R.id.leaderboard_list).apply {
+        view.findViewById<RecyclerView>(R.id.leaderboard_list).run {
             // use this setting to improve performance if you know that changes
             // in content do not change the layout size of the RecyclerView
             setHasFixedSize(true)

--- a/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/Leaderboard.kt
+++ b/NavigationBasicSample/app/src/main/java/com/example/android/navigationsample/Leaderboard.kt
@@ -32,24 +32,20 @@ import androidx.navigation.Navigation
  */
 class Leaderboard : Fragment() {
 
-    private lateinit var recyclerView: RecyclerView
-    private lateinit var viewAdapter: RecyclerView.Adapter<*>
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment
         val view = inflater.inflate(R.layout.fragment_leaderboard, container, false)
 
-        viewAdapter = MyAdapter(arrayOf("Flo", "Ly", "Jo"))
+        val viewAdapter = MyAdapter(arrayOf("Flo", "Ly", "Jo"))
 
-        recyclerView = view.findViewById<RecyclerView>(R.id.leaderboard_list).apply {
+        view.findViewById<RecyclerView>(R.id.leaderboard_list).run {
             // use this setting to improve performance if you know that changes
             // in content do not change the layout size of the RecyclerView
             setHasFixedSize(true)
 
             // specify an viewAdapter (see also next example)
             adapter = viewAdapter
-
         }
         return view
     }


### PR DESCRIPTION
After onDestroyView() runs, Fragment's Views are eligible for garbage collection. Ensure that we don't hold onto any references after onDestroyView() to allow for the Views to be garbage collected as soon as possible.

For the GithubBrowserSample, this required changing the AutoClearedValue class to clear the backing field when the Fragment's view is destroyed, rather than wait for the Fragment itself to be destroyed.

Test: ./run_all_tests.sh