### PR TITLE
Remove ext block from project build file; defs are in versions.gradle

### DIFF
--- a/BasicRxJavaSampleKotlin/build.gradle
+++ b/BasicRxJavaSampleKotlin/build.gradle
@@ -39,23 +39,3 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
-// Define versions in a single place
-ext {
-    // Sdk and tools
-    minSdkVersion = 15
-    targetSdkVersion = 26
-    compileSdkVersion = 26
-    buildToolsVersion = '26.0.1'
-
-    // App dependencies
-    supportLibraryVersion = '26.0.2'
-    junitVersion = '4.12'
-    mockitoVersion = '1.10.19'
-    hamcrestVersion = '1.3'
-    runnerVersion = '1.0.1'
-    rulesVersion = '1.0.1'
-    espressoVersion = '3.0.1'
-    architectureComponentsVersion = "1.0.0-alpha9"
-    rxjavaVersion = "2.1.3"
-    rxandroidVersion = "2.0.1"
-}


### PR DESCRIPTION
My CLA is on file.

The definitions in the app build file:
```
   minSdkVersion build_versions.min_sdk
   targetSdkVersion build_versions.target_sdk
```
which are in versions.gradle(recently upgraded for 29)
```

def build_versions = [:]
build_versions.min_sdk = 14
build_versions.compile_sdk = 29
build_versions.target_sdk = 29
build_versions.build_tools = "29.0.3"
ext.build_versions = build_versions

```
