### PR TITLE
Detach the first fragment without a loop (Advanced Navigation Sample)

### DIFF
--- a/NavigationAdvancedSample/app/src/main/java/com/example/android/navigationadvancedsample/NavigationExtensions.kt
+++ b/NavigationAdvancedSample/app/src/main/java/com/example/android/navigationadvancedsample/NavigationExtensions.kt
@@ -109,14 +109,7 @@ fun BottomNavigationView.setupWithNavController(
                             R.anim.nav_default_pop_exit_anim)
                         .attach(selectedFragment)
                         .setPrimaryNavigationFragment(selectedFragment)
-                        .apply {
-                            // Detach all other Fragments
-                            graphIdToTagMap.forEach { _, fragmentTagIter ->
-                                if (fragmentTagIter != newlySelectedItemTag) {
-                                    detach(fragmentManager.findFragmentByTag(firstFragmentTag)!!)
-                                }
-                            }
-                        }
+                        .detach(fragmentManager.findFragmentByTag(firstFragmentTag)!!)
                         .addToBackStack(firstFragmentTag)
                         .setReorderingAllowed(true)
                         .commit()


### PR DESCRIPTION
Detaching the first fragment does not need to be performed inside `graphIdToTagMap.forEach` because `firstFragmentTag` is not a variable of the loop.