### PR TITLE
Fix grammatical errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A collection of samples using the [Architecture Components](https://developer.an
 
 ### Samples
 
-* **[BasicSample](https://github.com/googlesamples/android-architecture-components/blob/master/BasicSample)** - Shows how to persist data using a SQLite database and Room. Also uses ViewModels and LiveData.
+* **[BasicSample](https://github.com/googlesamples/android-architecture-components/blob/master/BasicSample)** - Shows how to persist data using an SQLite database and Room. Also uses ViewModels and LiveData.
 
 * **[PersistenceContentProviderSample](https://github.com/googlesamples/android-architecture-components/blob/master/PersistenceContentProviderSample)** - Shows how to expose data via a Content Provider using Room.
 


### PR DESCRIPTION
References: 
1. Showcases the use of `an SQLite`
https://www.sqlite.org/whentouse.html#search_menubutton:~:text=Because%20an%20SQLite%20database%20is%20a,to%20extract%20the%20content%20as%20needed.

2 . `an SQLite` is grammatically correct as suggested by Grammarly’s browser extension which makes grammar suggestions.