### PR TITLE
Fix nullability in onActivitySaveInstanceState

### DIFF
--- a/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppInjector.kt
+++ b/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppInjector.kt
@@ -56,7 +56,7 @@ object AppInjector {
 
                 }
 
-                override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle?) {
+                override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
 
                 }
 


### PR DESCRIPTION
[This change](https://android.googlesource.com/platform/frameworks/base.git/+/324c73f212b702d70cd101547ac6aaa8cf347888%5E%21/#F0) in the framework marked both parameters to the [ActivityLifecycleCallbacks.onActivitySaveInstanceState](https://developer.android.com/reference/kotlin/android/app/Application.ActivityLifecycleCallbacks#onActivitySaveInstanceState(android.app.Activity,%20android.os.Bundle)) as NonNull, so the trailing ? on outState: Bundle should be removed.