### PR TITLE
GithubBrowserSample - Update loading_state visibility

### DIFF
--- a/GithubBrowserSample/app/src/main/res/layout/loading_state.xml
+++ b/GithubBrowserSample/app/src/main/res/layout/loading_state.xml
@@ -34,7 +34,7 @@
 
     <LinearLayout
         android:orientation="vertical"
-        app:visibleGone="@{resource.data == null}"
+        app:visibleGone="@{resource.status != Status.SUCCESS}"
         android:layout_width="wrap_content"
         android:gravity="center"
         android:padding="@dimen/default_margin"


### PR DESCRIPTION
When the return type is Flow<List<T>>, querying an empty table emits an empty list, thus may
result into hiding the container view. Update the container view visibility by the resource
status will enable usage of loading_state.xml even for resources with lists as the data.