### PR TITLE
GithubBrowserSample - Update loading_state visibility

### DIFF
--- a/GithubBrowserSample/app/src/main/res/layout/loading_state.xml
+++ b/GithubBrowserSample/app/src/main/res/layout/loading_state.xml
@@ -34,7 +34,7 @@
 
     <LinearLayout
         android:orientation="vertical"
-        app:visibleGone="@{resource.data == null}"
+        app:visibleGone="@{resource.status != Status.SUCCESS}"
         android:layout_width="wrap_content"
         android:gravity="center"
         android:padding="@dimen/default_margin"


### PR DESCRIPTION
When the return type in a Dao is Flow<List>, querying an empty table emits an empty list, thus resulting into hiding the
container view prematurely. Updating the visibility by a resource status fixes this case.