### PR TITLE
Performed fragment injection in  onFragmentAttached instead onFragmentCreated

### DIFF
--- a/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppInjector.kt
+++ b/GithubBrowserSample/app/src/main/java/com/android/example/github/di/AppInjector.kt
@@ -18,6 +18,7 @@ package com.android.example.github.di
 
 import android.app.Activity
 import android.app.Application
+import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -74,10 +75,10 @@ object AppInjector {
             activity.supportFragmentManager
                 .registerFragmentLifecycleCallbacks(
                     object : FragmentManager.FragmentLifecycleCallbacks() {
-                        override fun onFragmentCreated(
+                        override fun onFragmentAttached(
                             fm: FragmentManager,
                             f: Fragment,
-                            savedInstanceState: Bundle?
+                            context: Context
                         ) {
                             if (f is Injectable) {
                                 AndroidSupportInjection.inject(f)


### PR DESCRIPTION
Performing AndroidSupportInjection.inject method in onCreate of Fragment Life Cycle can lead to inconsistencies when the fragment is reattached which leads to the issue in which androidInjector() in the fragment returns null.

It is recommended in the Dagger documentation to perform it in onAttach() as mentioned in [When to Inject](https://dagger.dev/dev-guide/android.html#when-to-inject)