### PR TITLE
WorkManagerSample throws NullPointerException and IndexOutOfBoundsException

### DIFF
--- a/WorkManagerSample/app/src/main/java/com/example/background/FilterActivity.kt
+++ b/WorkManagerSample/app/src/main/java/com/example/background/FilterActivity.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -40,8 +41,12 @@ class FilterActivity : AppCompatActivity() {
             setContentView(root)
             bindViews(this)
             // Check to see if we have output.
-            viewModel.workInfo.observe(this@FilterActivity) { info ->
-                onStateChange(info, this)
+            viewModel.workInfoList.observe(this@FilterActivity) { infoList ->
+                if (infoList.isNotEmpty()) {
+                    onStateChange(infoList[0], this)
+                } else {
+                    Log.e(TAG, "WorkInfo is empty.")
+                }
             }
         }
     }
@@ -107,6 +112,8 @@ class FilterActivity : AppCompatActivity() {
     }
 
     companion object {
+
+        private const val TAG = "FilterActivity"
 
         /**
          * Creates a new intent which can be used to start [FilterActivity].

--- a/WorkManagerSample/app/src/main/java/com/example/background/FilterViewModel.kt
+++ b/WorkManagerSample/app/src/main/java/com/example/background/FilterViewModel.kt
@@ -31,8 +31,8 @@ class FilterViewModel(application: Application) : ViewModel() {
 
     private val workManager = WorkManager.getInstance(application)
 
-    internal val workInfo =
-        workManager.getWorkInfosByTagLiveData(Constants.TAG_OUTPUT).map { it[0] }
+    internal val workInfoList =
+        workManager.getWorkInfosByTagLiveData(Constants.TAG_OUTPUT)
 
     internal fun apply(imageOperations: ImageOperations) {
         imageOperations.continuation.enqueue()

--- a/WorkManagerSample/app/src/main/java/com/example/background/SelectImageActivity.kt
+++ b/WorkManagerSample/app/src/main/java/com/example/background/SelectImageActivity.kt
@@ -139,9 +139,13 @@ class SelectImageActivity : AppCompatActivity() {
         }
     }
 
-    private fun handleImageRequestResult(data: Intent) {
+    private fun handleImageRequestResult(intent: Intent) {
         // Get the imageUri the user picked, from the Intent.ACTION_PICK result.
-        val imageUri = data.clipData!!.getItemAt(0).uri
+        val imageUri = if (intent.clipData == null) {
+            intent.data
+        } else {
+            intent.clipData!!.getItemAt(0).uri
+        }
 
         if (imageUri == null) {
             Log.e(TAG, "Invalid input image Uri.")


### PR DESCRIPTION
1. When selecting a image, there's a IndexOutOfBoundsException in FilterViewModel.  Change FilterViewModel > workInfo to return WorkInfo List, it works fine. Accordingly, observer needs to be changed so that it can accepts List<WorkInfo>.
2. SelectImageActivity > handleImageRequestResult: It should be changed to handle both clipData and data, otherwise NullPointerException will throw.