### PR TITLE
afterObserve.invoke() only if latch is satisfied

### DIFF
--- a/LiveDataSample/app/src/test/java/com/android/example/livedatabuilder/util/LiveDataTestUtil.kt
+++ b/LiveDataSample/app/src/test/java/com/android/example/livedatabuilder/util/LiveDataTestUtil.kt
@@ -43,10 +43,10 @@ fun <T> LiveData<T>.getOrAwaitValue(
     }
     this.observeForever(observer)
 
-    afterObserve.invoke()
-
     // Don't wait indefinitely if the LiveData is not set.
-    if (!latch.await(time, timeUnit)) {
+    if (latch.await(time, timeUnit)) {
+        afterObserve.invoke()        
+    } else {
         this.removeObserver(observer)
         throw TimeoutException("LiveData value was never set.")
     }


### PR DESCRIPTION
`getOrAwaitValue` in `LiveDataTestUtil` should invoke `afterObserve` only if the latch is satisfied (i.e. data was changed)