### PR TITLE
Fix fab button crash issue with double tap [issue- #1027]

### DIFF
--- a/MADSkillsNavigationSample/app/src/main/java/com/android/samples/donuttracker/DonutList.kt
+++ b/MADSkillsNavigationSample/app/src/main/java/com/android/samples/donuttracker/DonutList.kt
@@ -23,9 +23,9 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.observe
-import androidx.navigation.findNavController
 import androidx.navigation.fragment.findNavController
 import com.android.samples.donuttracker.databinding.DonutListBinding
+import com.android.samples.donuttracker.extension.clickWithDebounce
 import com.android.samples.donuttracker.storage.DonutDatabase
 import kotlinx.android.synthetic.main.donut_list.*
 
@@ -60,8 +60,8 @@ class DonutList : Fragment() {
 
         recyclerView.adapter = adapter
 
-        binding.fab.setOnClickListener { fabView ->
-            fabView.findNavController().navigate(
+        binding.fab.clickWithDebounce {
+            findNavController().navigate(
                 DonutListDirections.actionDonutListToDonutEntryDialogFragment()
             )
         }

--- a/MADSkillsNavigationSample/app/src/main/java/com/android/samples/donuttracker/extension/ViewExtension.kt
+++ b/MADSkillsNavigationSample/app/src/main/java/com/android/samples/donuttracker/extension/ViewExtension.kt
@@ -1,0 +1,18 @@
+package com.android.samples.donuttracker.extension
+
+import android.view.View
+
+fun View.clickWithDebounce(debounceTime: Long = 1000L, action: () -> Unit) {
+    this.setOnClickListener(object : View.OnClickListener {
+        private var lastClickTime: Long = 0
+
+        override fun onClick(v: View?) {
+            if (System.currentTimeMillis() - lastClickTime < debounceTime) {
+                return
+            }
+            action()
+            lastClickTime = System.currentTimeMillis()
+        }
+
+    })
+}


### PR DESCRIPTION
I create a view extension called "`clickWithDebounce`" to fix fab button crash issue with double tap. [issue #1027 ]
Clicks shorter than 1 second cannot be made.
Thus, we can use "`clickWithDebounce`" instead of  "`setOnClickListener`" without any crash. 