### PR TITLE
- keeping only one to one migration relation-ship

### DIFF
--- a/PersistenceMigrationsSample/app/src/room3/java/com/example/android/persistence/migrations/UsersDatabase.java
+++ b/PersistenceMigrationsSample/app/src/room3/java/com/example/android/persistence/migrations/UsersDatabase.java
@@ -102,32 +102,6 @@ public abstract class UsersDatabase extends RoomDatabase {
         }
     };
 
-    /**
-     * Migrate from
-     * version 1 - using the SQLiteDatabase API
-     * to
-     * version 4 - using Room where {@link User} has a new field: {@link User#mDate} and
-     * {@link User#mId} is a String
-     */
-    @VisibleForTesting
-    static final Migration MIGRATION_1_4 = new Migration(1, 4) {
-        @Override
-        public void migrate(SupportSQLiteDatabase database) {
-            // Create the new table
-            database.execSQL(
-                    "CREATE TABLE users_new (userid TEXT, username TEXT, last_update INTEGER,"
-                            + " PRIMARY KEY(userid))");
-            // Copy the data
-            database.execSQL("INSERT INTO users_new (userid, username, last_update) "
-                    + "SELECT userid, username, 0 "
-                    + "FROM users");
-            // Remove the old table
-            database.execSQL("DROP TABLE users");
-            // Change the table name to the correct one
-            database.execSQL("ALTER TABLE users_new RENAME TO users");
-        }
-    };
-
     public static UsersDatabase getInstance(Context context) {
         synchronized (sLock) {
             if (INSTANCE == null) {


### PR DESCRIPTION
In practice, it's a good practice to have a one-to-one relationship between the starting version and a migration. Each version should have a unique migration associated with it to ensure clarity and predictability in the migration process.

In this code snippet, it seems like MIGRATION_1_2 is a placeholder for migrating from version 1 to version 2, and MIGRATION_1_4 is a placeholder for migrating from version 1 to version 4. However, having both is redundant and could be misleading.

To address this, it would be better to consolidate these into a single migration from version 1 to version 4, which encompasses all the required changes up to version 4. This single migration would ensure that any device at version 1 would correctly migrate to version 4.

So, it would be more appropriate to have a single migration like MIGRATION_1_4 that encompasses all necessary changes from version 1 to version 4. This helps to avoid potential confusion and ensures a clear migration path for all devices.